### PR TITLE
fix: associate unexected errs w/ rules; always include validation result details

### DIFF
--- a/Dockerfile.devspace
+++ b/Dockerfile.devspace
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM golang:alpine3.18 as builder
+FROM --platform=$TARGETPLATFORM golang:alpine3.19 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/internal/validators/oci_validator_test.go
+++ b/internal/validators/oci_validator_test.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	vrr = buildValidationResult(v1alpha1.OciRegistryRule{})
+	vrr = BuildValidationResult(v1alpha1.OciRegistryRule{})
 )
 
 func TestGenerateRef(t *testing.T) {

--- a/pkg/oci/oci_client.go
+++ b/pkg/oci/oci_client.go
@@ -246,10 +246,8 @@ func (c *Client) VerifySignature(ctx context.Context, ref name.Reference) ([]str
 			errs = append(errs, err)
 			continue
 		}
-
 		if hasValidSignature {
-			details = nil
-			errs = nil
+			details = append(details, fmt.Sprintf("verified signature for %s", ref))
 			return details, errs
 		}
 	}


### PR DESCRIPTION
## Issue
<!-- Link to the github issue this PR address, ie: #123 -->

## Description
Fix multiple issues with validation results:
- validation results for unexpected errors weren't setting ValidationRule or ValidationType, and hence couldn't be associated with a particular rule in the OciValidator
- validation results were omitting details that had been added when errors occurred
- positive details weren't being added to validation results in all cases
