### PR TITLE
refactor: derive authn keychain from host

### DIFF
--- a/internal/controller/ocivalidator_controller.go
+++ b/internal/controller/ocivalidator_controller.go
@@ -24,7 +24,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
+	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
+	acr "github.com/chrismellard/docker-credential-acr-env/pkg/credhelper"
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/v1/google"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -118,7 +123,7 @@ func (r *OciValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		ociClient, err := oci.NewOCIClient(
 			oci.WithBasicAuth(username, password),
-			oci.WithMultiAuth(),
+			oci.WithMultiAuth(getKeychain(rule.Host)),
 			oci.WithTLSConfig(rule.InsecureSkipTLSVerify, rule.CaCert, ""),
 			oci.WithVerificationPublicKeys(pubKeys),
 		)
@@ -150,6 +155,21 @@ func (r *OciValidatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.OciValidator{}).
 		Complete(r)
+}
+
+// getKeychain returns the default authn keychain derived from an OCI host.
+func getKeychain(host string) []authn.Keychain {
+	keychain := []authn.Keychain{
+		authn.DefaultKeychain,
+	}
+	if strings.Contains(host, "azurecr.io") {
+		keychain = append(keychain, authn.NewKeychainFromHelper(acr.ACRCredHelper{}))
+	} else if strings.Contains(host, "gcr.io") {
+		keychain = append(keychain, google.Keychain)
+	} else if strings.Contains(host, "ecr.aws") || strings.Contains(host, "amazonaws.com") {
+		keychain = append(keychain, authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithClientFactory(api.DefaultClientFactory{}))))
+	}
+	return keychain
 }
 
 // secretKeyAuth retrieves the username and password from the secret referenced in the rule's auth field.

--- a/pkg/oci/oci_client.go
+++ b/pkg/oci/oci_client.go
@@ -13,13 +13,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
-	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
-	acr "github.com/chrismellard/docker-credential-acr-env/pkg/credhelper"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/validate"
 	"github.com/validator-labs/validator/pkg/util"
@@ -102,14 +98,9 @@ func WithBasicAuth(username, password string) Option {
 }
 
 // WithMultiAuth configures the OCI client with multiple authentication keychains.
-func WithMultiAuth() Option {
+func WithMultiAuth(keychain []authn.Keychain) Option {
 	return func(c *Client) {
-		c.keychain = authn.NewMultiKeychain(
-			authn.DefaultKeychain,
-			google.Keychain,
-			authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithClientFactory(api.DefaultClientFactory{}))),
-			authn.NewKeychainFromHelper(acr.ACRCredHelper{}),
-		)
+		c.keychain = authn.NewMultiKeychain(keychain...)
 	}
 }
 


### PR DESCRIPTION
## Issue
N/A

## Description
Derive authn keychain based on the OCI host. This avoids errors such as the following:

```console
manager time="2024-08-02T22:01:46Z" level=error msg="Error parsing the serverURL" error="docker-credential-ecr
-login can only be used with Amazon Elastic Container Registry." serverURL=gcr.io
```

When validating non-ECR artifacts.
