### PR TITLE
chore: only add auth and pubkeys when they're not empty

### DIFF
--- a/internal/controller/ocivalidator_controller.go
+++ b/internal/controller/ocivalidator_controller.go
@@ -104,14 +104,18 @@ func (r *OciValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			l.Error(err, "failed to get secret auth", "ruleName", rule.Name())
 			return ctrl.Result{}, err
 		}
-		auths[rule.Name()] = []string{username, password}
+		if username != "" || password != "" {
+			auths[rule.Name()] = []string{username, password}
+		}
 
 		pubKeys, err := r.signaturePubKeys(req, rule)
 		if err != nil {
 			l.Error(err, "failed to get signature verification public keys", "ruleName", rule.Name())
 			return ctrl.Result{}, err
 		}
-		allPubKeys[rule.Name()] = pubKeys
+		if pubKeys != nil {
+			allPubKeys[rule.Name()] = pubKeys
+		}
 	}
 
 	// Validate the rules


### PR DESCRIPTION
## Issue
N/A

## Description
We were always populating the auth and allPubKeys maps which meant that we were unneccesarily calling the oci clients `WithVerificationPublicKeys` and `WithBasicAuth` functions for every rule (even those with no auth or pubkeys).

Nothing was actually broken, but this is a more correct implementation
