### PR TITLE
fix: support private ecr registry validation with a per rule aws env vars

### DIFF
--- a/internal/controller/ocivalidator_controller.go
+++ b/internal/controller/ocivalidator_controller.go
@@ -51,12 +51,6 @@ type OciValidatorReconciler struct {
 //+kubebuilder:rbac:groups=validation.spectrocloud.labs,resources=ocivalidators/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=validation.spectrocloud.labs,resources=ocivalidators/finalizers,verbs=update
 
-const (
-	accessKeyEnv       = "AWS_ACCESS_KEY_ID"     // #nosec
-	secretAccessKeyEnv = "AWS_SECRET_ACCESS_KEY" // #nosec
-	sessionTokenEnv    = "AWS_SESSION_TOKEN"     // #nosec
-)
-
 // Reconcile reconciles each rule found in each OCIValidator in the cluster and creates ValidationResults accordingly
 func (r *OciValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := r.Log.V(0).WithValues("name", req.Name, "namespace", req.Namespace)
@@ -149,10 +143,6 @@ func (r *OciValidatorReconciler) auth(req ctrl.Request, rule v1alpha1.OciRegistr
 		return rule.Auth.Basic.Username, rule.Auth.Basic.Password, nil
 	}
 
-	if rule.Auth.ECR != nil {
-		return r.ecrAuth(rule)
-	}
-
 	return "", "", nil
 }
 
@@ -189,25 +179,6 @@ func (r *OciValidatorReconciler) secretKeyAuth(req ctrl.Request, rule v1alpha1.O
 	}
 
 	return username, password, nil
-}
-
-func (r *OciValidatorReconciler) ecrAuth(rule v1alpha1.OciRegistryRule) (string, string, error) {
-	if err := os.Setenv(accessKeyEnv, rule.Auth.ECR.AccessKeyID); err != nil {
-		return "", "", err
-	}
-	r.Log.Info("Set environment variable", "key", accessKeyEnv)
-
-	if err := os.Setenv(secretAccessKeyEnv, rule.Auth.ECR.SecretAccessKey); err != nil {
-		return "", "", err
-	}
-	r.Log.Info("Set environment variable", "key", secretAccessKeyEnv)
-
-	if err := os.Setenv(sessionTokenEnv, rule.Auth.ECR.SessionToken); err != nil {
-		return "", "", err
-	}
-	r.Log.Info("Set environment variable", "key", sessionTokenEnv)
-
-	return "", "", nil
 }
 
 func (r *OciValidatorReconciler) signaturePubKeys(req ctrl.Request, rule v1alpha1.OciRegistryRule) ([][]byte, error) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,4 +8,11 @@ const (
 	OciRegistry string = "oci-registry"
 	// EcrRegistry is the ECR registry string
 	EcrRegistry string = "ecr-registry"
+
+	// AwsAccessKey is the key for the AWS access key
+	AwsAccessKey = "AWS_ACCESS_KEY_ID" // #nosec
+	// AwsSecretAccessKey is the key for the AWS secret access key
+	AwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY" // #nosec
+	// AwsSessionToken is the key for the AWS session token
+	AwsSessionToken = "AWS_SESSION_TOKEN" // #nosec
 )


### PR DESCRIPTION
## Issue
N/A

## Description
Previously, if different aws creds were required to validate different registry rules, we would set the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` for each rule. This would cause the latest env vars set to be used while validating all rules.

Now, we set the env vars on a per rule basis