### PR TITLE
fix: embedding structs related to `validationrule.Interface`

### DIFF
--- a/api/v1alpha1/ocivalidator_types.go
+++ b/api/v1alpha1/ocivalidator_types.go
@@ -45,7 +45,7 @@ func (s OciValidatorSpec) ResultCount() int {
 
 // OciRegistryRule defines the validation rule for an OCI registry.
 type OciRegistryRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// Name is a unique name for the OciRegistryRule.
 	RuleName string `json:"name" yaml:"name"`


### PR DESCRIPTION
## Description
Noticed when trying to integrate latest plugin releases with validatorctl that tests started failing because the CRD couldn't be applied. It complained about unknown fields. This is because the json tag used when embedding the struct lacked "inline". This fixes that.
