### PR TITLE
fix: YAML rendering of structs embedded in rules

### DIFF
--- a/api/v1alpha1/ocivalidator_types.go
+++ b/api/v1alpha1/ocivalidator_types.go
@@ -48,7 +48,7 @@ func (s OciValidatorSpec) ResultCount() int {
 
 // OciRegistryRule defines the validation rule for an OCI registry.
 type OciRegistryRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// Name is a unique name for the OciRegistryRule.
 	RuleName string `json:"name" yaml:"name"`


### PR DESCRIPTION
## Description
In previous PRs, we made the plugin rules implement the new `validationrule.Interface` interface. We did not include YAML tags in rules to specify that the new field (`validationrule.ManuallyNamed` or `validationrule.AutomaticallyNamed` depending on the rule) should not be included when the rules are rendered to YAML. The validatorctl CLI renders the rules to YAML as part of what it does, so this caused errors when validatorctl tried to apply validator CRDs it generated to its cluster.