### PR TITLE
feat: adding annotation to define reconciliation frequency

### DIFF
--- a/config/samples/annotation.yaml
+++ b/config/samples/annotation.yaml
@@ -1,0 +1,14 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: OciValidator
+metadata:
+  name: ocivalidator-sample-public-oci-registries
+  namespace: validator
+  annotations:
+    validation.validator.labs/reconciliation-frequency: "10"
+spec:
+  ociRegistryRules:
+    # public oci registry artifact with tag
+    - name: "public oci registry with tag"
+      host: "docker.io"
+      artifacts:
+        - ref: "library/redis:7.2.4"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -15,4 +15,7 @@ const (
 	AwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY" // #nosec
 	// AwsSessionToken is the key for the AWS session token
 	AwsSessionToken = "AWS_SESSION_TOKEN" // #nosec
+
+	// ReconciliationFrequencyAnnotation is annotation key for reconciliation frequency
+	ReconciliationFrequencyAnnotation = "validation.validator.labs/reconciliation-frequency"
 )


### PR DESCRIPTION
## Issue
partially resolves validator-labs/validator#358

## Description

- Added the annotation `validation.validator.labs/reconciliation-frequency`.
- The annotation value is an `integer` representing the time in `seconds`.
- I added a constant to define the annotation key.
- The controller checks if the annotation has been defined. If it finds the annotation, it uses that. If it doesn't find the annotation, it takes `120` seconds as default.
- Added a sample `OciValidator` manifest as an example. 