### PR TITLE
chore: make reviewable

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
   enable:
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - ginkgolinter
     - goconst
     - gocyclo

--- a/chart/validator-plugin-oci/crds/validation.spectrocloud.labs_ocivalidators.yaml
+++ b/chart/validator-plugin-oci/crds/validation.spectrocloud.labs_ocivalidators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: ocivalidators.validation.spectrocloud.labs
 spec:
   group: validation.spectrocloud.labs
@@ -57,7 +57,6 @@ spec:
                               <repository-path>/<artifact-name>
                               <repository-path>/<artifact-name>:<tag>
                               <repository-path>/<artifact-name>@<digest>
-
 
                               When no tag or digest are specified, the default tag "latest" is used.
                             type: string

--- a/config/crd/bases/validation.spectrocloud.labs_ocivalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_ocivalidators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: ocivalidators.validation.spectrocloud.labs
 spec:
   group: validation.spectrocloud.labs
@@ -57,7 +57,6 @@ spec:
                               <repository-path>/<artifact-name>
                               <repository-path>/<artifact-name>:<tag>
                               <repository-path>/<artifact-name>@<digest>
-
 
                               When no tag or digest are specified, the default tag "latest" is used.
                             type: string


### PR DESCRIPTION
Also addresses this warning:
```
level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
```