### PR TITLE
feat: added reconciliation frequency annotation

### DIFF
--- a/config/samples/annotation.yaml
+++ b/config/samples/annotation.yaml
@@ -1,0 +1,13 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: OciValidator
+metadata:
+  name: ocivalidator-sample-public-oci-registries
+  namespace: validator
+  annotations:
+    validation.validator.labs/reconciliation-frequency: "10"
+spec:
+  ociRegistryRules:
+    - name: "public oci registry with tag"
+      host: "docker.io"
+      artifacts:
+        - ref: "library/redis:7.2.4"

--- a/internal/controller/ocivalidator_controller.go
+++ b/internal/controller/ocivalidator_controller.go
@@ -122,7 +122,7 @@ func (r *OciValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	frequencyResult := plugins.FrequencyFromAnnotations(l, validator.Annotations)
-	l.Info("Requeuing for re-validation in ", "minutes", frequencyResult.RequeueAfter)
+	l.Info("Requeuing for re-validation in ", "seconds", frequencyResult.RequeueAfter)
 
 	return frequencyResult, nil
 }

--- a/internal/controller/ocivalidator_controller.go
+++ b/internal/controller/ocivalidator_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vapi "github.com/validator-labs/validator/api/v1alpha1"
+	"github.com/validator-labs/validator/pkg/plugins"
 	vres "github.com/validator-labs/validator/pkg/validationresult"
 
 	"github.com/validator-labs/validator-plugin-oci/api/v1alpha1"
@@ -120,8 +121,10 @@ func (r *OciValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	l.Info("Requeuing for re-validation in two minutes.")
-	return ctrl.Result{RequeueAfter: time.Second * 120}, nil
+	frequencyResult := plugins.FrequencyFromAnnotations(l, validator.Annotations)
+	l.Info("Requeuing for re-validation in ", "minutes", frequencyResult.RequeueAfter)
+
+	return frequencyResult, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
## Issue
Integrates annotation helper function from validator-labs/validator#358

## Description
- annotation for defining reconciliation frequency can now be specified.
- providing the annotation is optional
- example added to `config/samples/`

## Notes
I tested the changes with a kind cluster. I had to remove `- "--metrics-bind-address=127.0.0.1:8080"` from the manager's arguments in `config/default/manager_auth_proxy_patch.yaml`. However, I reverted the change for this PR. 