### PR TITLE
fix: metrics targetPort https -> 8443

### DIFF
--- a/chart/validator-plugin-oci/README.md
+++ b/chart/validator-plugin-oci/README.md
@@ -23,7 +23,7 @@ The following table lists the configurable parameters of the Validator-plugin-oc
 | `controllerManager.replicas` |  | `1` |
 | `controllerManager.serviceAccount.annotations` |  | `{}` |
 | `kubernetesClusterDomain` |  | `"cluster.local"` |
-| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": "https"}]` |
+| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": 8443}]` |
 | `metricsService.type` |  | `"ClusterIP"` |
 | `env` |  | `[]` |
 | `proxy.enabled` |  | `false` |

--- a/chart/validator-plugin-oci/values.yaml
+++ b/chart/validator-plugin-oci/values.yaml
@@ -28,7 +28,7 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP
 
 # Optional environment variable configuration


### PR DESCRIPTION
Metrics server is exposed on port 8443. This PR updates the metrics service chart value to match this, to ensure it's accessible.
